### PR TITLE
[codex] FilterIsActive の公開条件に公開開始日時を追加

### DIFF
--- a/internal/repository/announcement.go
+++ b/internal/repository/announcement.go
@@ -22,7 +22,7 @@ func (r *announcementRepository) GetAnnouncements(ctx context.Context, query dom
 	dbQuery := r.db.WithContext(ctx)
 
 	if query.FilterIsActive {
-		dbQuery = dbQuery.Where("available_until IS NULL OR available_until > NOW()")
+		dbQuery = dbQuery.Where("available_from <= NOW()").Where("available_until IS NULL OR available_until > NOW()")
 	}
 
 	sortDateDirection := func() string {


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントするときは日本語でお願いします -->

# やったこと

- `FilterIsActive` の条件に `available_from <= NOW()` を追加
- 公開開始前の announcement が active として取得されないよう修正

# 確認したこと

- [x] 差分上、active 条件が「公開開始済み」かつ「公開終了前または終了日時未設定」になっていることを確認

# メモ

- これまでは公開終了日時のみを見ていたため、公開開始前のデータも active 扱いになっていた
- devで動作確認済み
- マージ後、qaとprodに手動デプロイ